### PR TITLE
chore(package): Upgrade to go 1.20

### DIFF
--- a/gcp-to-azure-auth/go.mod
+++ b/gcp-to-azure-auth/go.mod
@@ -1,6 +1,6 @@
 module gcp-to-azure-auth
 
-go 1.19
+go 1.20
 
 require (
 	cloud.google.com/go/iam v0.4.0


### PR DESCRIPTION
Updates go to version 1.20 and runs `go mod tidy`.

Before:
  `go 1.19`

Before:
  `go 1.17`

After:
  `go 1.20`