### PR TITLE
feat: Demo of wrapping/unwrapping errors in Go

### DIFF
--- a/2025-week-19/bendik-go-custom-errors/README.md
+++ b/2025-week-19/bendik-go-custom-errors/README.md
@@ -1,0 +1,8 @@
+# Wrapping and unwrapping errors in Go
+
+Demonstration of how to do wrapping and unwrapping of errors in Go.
+
+Followup of <https://github.com/coopnorge/demos/pull/442>
+
+Implemented for this demo session:
+<https://github.com/coopnorge/engineering-issues/issues/445>

--- a/2025-week-19/bendik-go-custom-errors/cmd/1_customerror_recap/main.go
+++ b/2025-week-19/bendik-go-custom-errors/cmd/1_customerror_recap/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+)
+
+func main() {
+	var err error
+	_ = err
+
+	err = someFunction()
+	pe := &CustomError{}
+	if errors.As(err, &pe) {
+		log.Printf("Got CustomError with value: %s", pe.Value)
+	} else {
+		panic("Expected errors.As to match the custom error")
+	}
+
+	log.Printf("Done.")
+}
+
+func someFunction() error {
+	return &CustomError{
+		Value: "some value",
+	}
+}
+
+// CustomError implements the error interface as a receiver on a POINTER to the struct.
+type CustomError struct {
+	Value string
+}
+
+func (e *CustomError) Error() string {
+	return fmt.Sprintf("some custom error with additional property: %s", e.Value)
+}

--- a/2025-week-19/bendik-go-custom-errors/cmd/2_wrapping_errors/main.go
+++ b/2025-week-19/bendik-go-custom-errors/cmd/2_wrapping_errors/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+)
+
+var errDBUserNotFound error = errors.New("user not found in database")
+
+func main() {
+	var err error
+	_ = err
+
+	err = someFunction()
+	if errors.Is(err, errDBUserNotFound) {
+		log.Printf("Found specific errDBUserNotFound error, 3 layers deep!")
+	} else {
+		panic("Expected errors.Is to find the specific error")
+	}
+
+	log.Printf("Done.")
+}
+
+func someFunction() error {
+	err := someDatabaseFunction()
+	if err != nil {
+		return fmt.Errorf("something went wrong when calling the database: %w", err)
+	}
+	return nil
+}
+
+func someDatabaseFunction() error {
+	return fmt.Errorf("error when calling the database: %w", errDBUserNotFound)
+}

--- a/2025-week-19/bendik-go-custom-errors/cmd/3_multierror/main.go
+++ b/2025-week-19/bendik-go-custom-errors/cmd/3_multierror/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+)
+
+var errDBUserNotFound error = errors.New("user not found in database")
+
+func main() {
+	var err error
+	_ = err
+
+	err = someFunction()
+	if errors.Is(err, errDBUserNotFound) {
+		log.Printf("Found specific errDBUserNotFound error!")
+	} else {
+		panic("Expected errors.Is to find the specific error")
+	}
+
+	log.Printf("Done.")
+}
+
+func someFunction() error {
+	// Note: Not returning early if there is an error
+	err1 := someDatabaseFunction()
+	err2 := someHTTPClientFunction()
+	return errors.Join(err1, err2)
+}
+
+func someDatabaseFunction() error {
+	return fmt.Errorf("error when calling the database: %w", errDBUserNotFound)
+}
+
+func someHTTPClientFunction() error {
+	return fmt.Errorf("error when calling an HTTP endpoint")
+}

--- a/2025-week-19/bendik-go-custom-errors/cmd/4_custom_multierror/main.go
+++ b/2025-week-19/bendik-go-custom-errors/cmd/4_custom_multierror/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+)
+
+var errDBUserNotFound error = errors.New("user not found in database")
+
+func main() {
+	var err error
+	_ = err
+
+	err = someFunction()
+	pe := &CustomError{}
+	if errors.As(err, &pe) {
+		log.Printf("Got CustomError with value: %s", pe.Value)
+	} else {
+		panic("Expected errors.As to match the custom error")
+	}
+
+	if errors.Is(err, errDBUserNotFound) {
+		log.Printf("Found specific errDBUserNotFound error!")
+	} else {
+		panic("Expected errors.Is to find the specific error")
+	}
+
+	log.Printf("Done.")
+}
+
+func someFunction() error {
+	// Note: Not returning early if there is an error
+	err1 := someDatabaseFunction()
+	err2 := someHTTPClientFunction()
+
+	return &CustomError{
+		Value:  "some value",
+		Errors: []error{err1, err2},
+	}
+}
+
+func someDatabaseFunction() error {
+	return fmt.Errorf("error when calling the database: %w", errDBUserNotFound)
+}
+
+func someHTTPClientFunction() error {
+	return fmt.Errorf("error when calling an HTTP endpoint")
+}
+
+// CustomError implements the error interface as a receiver on a POINTER to the struct.
+type CustomError struct {
+	Value  string
+	Errors []error
+}
+
+func (e *CustomError) Error() string {
+	return fmt.Sprintf("some custom error with additional property: %s", e.Value)
+}
+
+// "Unwrap() []error" and "Unwrap() error" are "hidden interfaces".
+// https://cs.opensource.google/go/go/+/refs/tags/go1.24.2:src/errors/wrap.go;l=61-76
+func (e *CustomError) Unwrap() []error {
+	return e.Errors
+}

--- a/2025-week-19/bendik-go-custom-errors/go.mod
+++ b/2025-week-19/bendik-go-custom-errors/go.mod
@@ -1,0 +1,3 @@
+module github.com/coopnorge/bendik-go-custom-errors
+
+go 1.23


### PR DESCRIPTION
Demonstration of how to do wrapping and unwrapping of errors in Go.

Followup of <https://github.com/coopnorge/demos/pull/442>

Implemented for this demo session:
<https://github.com/coopnorge/engineering-issues/issues/445>
